### PR TITLE
feat (gradation control): extend interface for gradation control

### DIFF
--- a/src/GradationControl.cpp
+++ b/src/GradationControl.cpp
@@ -11,7 +11,7 @@ GradationControl::~GradationControl()
 {
 }
 
-float GradationControl::set_gradation( float max_iref, float time, bool up, bool down, float on, float off )
+float GradationControl::set_gradation( float max_iref, float time, bool up, bool down, float on, float off, bool hold_on, bool hold_off )
 {
 	int		iref;
 	float	step_duration;
@@ -64,12 +64,12 @@ float GradationControl::set_gradation( float max_iref, float time, bool up, bool
 			off_i	= i;
 			break;
 		}
-	}		
+	}
 
-	reg[ 0 ]	= (up << 7) | (down << 6) |  (iref_inc - 1);	// for RAMP_RATE_GRPn
-	reg[ 1 ]	= ( cycle_time_i << 6 ) | (multi_fctr - 1);		// for STEP_TIME_GRPn
-	reg[ 2 ]	= 0xC0 | ( on_i << 3) | off_i;					// for HOLD_CNTL_GRPn
-	reg[ 3 ]	= iref;											// for IREF_GRPn
+	reg[ 0 ]	= (up << 7) | (down << 6) |  (iref_inc - 1);					// for RAMP_RATE_GRPn
+	reg[ 1 ]	= ( cycle_time_i << 6 ) | (multi_fctr - 1);						// for STEP_TIME_GRPn
+	reg[ 2 ]	= (hold_on << 7) | (hold_off << 6) | ( on_i << 3) | off_i;		// for HOLD_CNTL_GRPn
+	reg[ 3 ]	= iref;															// for IREF_GRPn
 	
 	devp->reg_access( devp->arp[ SETTING ] + group * 4, reg, sizeof( reg ) );
 	

--- a/src/GradationControl.h
+++ b/src/GradationControl.h
@@ -52,9 +52,11 @@ public:
 	 * @param down option: ramp-down enable. default: true
 	 * @param on option: hold-ON duration in second. default: 0.0
 	 * @param off option: hold-OFF duration in second. default: 0.0
+	 * @param hold_on option: hold-on enable. default: true
+	 * @param hold_off option: hold-off enable. default: true
 	 * @return Actual cycle period after calculation
 	 */
-	float set_gradation( float max_iref, float time, bool up = true, bool down = true, float on = 0.0, float off = 0.0 );
+	float set_gradation( float max_iref, float time, bool up = true, bool down = true, float on = 0.0, float off = 0.0, bool hold_on = true, bool hold_off = true );
 
 	/** Channel assign into group
 	 *


### PR DESCRIPTION
Added hold_on and hold_off inputs to function set_gradation.
Added the new boolean flags after float values to not break existing function calles based on previous versions
(fully backwards compatible)

removed trailing white space

resolves #1